### PR TITLE
Remove separate locationManager from MapView

### DIFF
--- a/LookARound/Controllers/ARoundViewController.swift
+++ b/LookARound/Controllers/ARoundViewController.swift
@@ -17,11 +17,9 @@ import CoreLocation
 class ARoundViewController: UIViewController, SceneLocationViewDelegate, FilterViewControllerDelegate, ARMapViewDelegate {
     @IBOutlet weak var filterButton: UIButton!
     @IBOutlet weak var mapButton: UIButton!
-    @IBOutlet weak var mapView: MapView!
     @IBOutlet var contentView: UIView!
-    @IBOutlet weak var mapBottom: NSLayoutConstraint!
-    @IBOutlet weak var mapTop: NSLayoutConstraint!
     
+    var mapView: MapView!
     let sceneLocationView = SceneLocationView()
     var locationNodes = [LocationAnnotationNode]()
     var currentLocation: CLLocation! {
@@ -31,6 +29,9 @@ class ARoundViewController: UIViewController, SceneLocationViewDelegate, FilterV
     }
     var currentCoordinates: CLLocationCoordinate2D?
     
+    var mapTop: NSLayoutConstraint!
+    var mapBottom: NSLayoutConstraint!
+    
     var adjustNorthByTappingSidesOfScreen = true
     var centerMapOnUserLocation: Bool = true
     
@@ -39,7 +40,9 @@ class ARoundViewController: UIViewController, SceneLocationViewDelegate, FilterV
         
         addARScene()
         initMap()
-
+        
+        performFirstSearch()
+        
         // Set up the UI elements as per the app theme
         prepButtonsWithARTheme(buttons: [filterButton, mapButton])
         
@@ -84,6 +87,32 @@ class ARoundViewController: UIViewController, SceneLocationViewDelegate, FilterV
         // Dispose of any resources that can be recreated.
     }
     
+    // MARK: - 2D Map setup
+    func initMap()
+    {
+        guard let coordinates = currentCoordinates else {
+            print("not ready for search - no coordinates!")
+            return
+        }
+        mapView = MapView(at: coordinates)
+        mapView.alpha = 0.9
+        mapView.delegate = self
+        
+        view.insertSubview(mapView, at: 1)
+        mapView.translatesAutoresizingMaskIntoConstraints = false
+        mapTop = mapView.topAnchor.constraint(equalTo: view.centerYAnchor)
+        mapTop.isActive = true
+        mapView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor).isActive = true
+        mapView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor).isActive = true
+        mapBottom = mapView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        mapBottom.isActive = true
+
+        // Move mapView offscreen (below view)
+        self.view.layoutIfNeeded() // Do this, otherwise frame.height will be incorrect
+        mapTop.constant = mapView.frame.height
+        mapBottom.constant = mapView.frame.height
+    }
+    
     // MARK: - AR scene setup
     func addARScene() {
         view.insertSubview(sceneLocationView, at: 0)
@@ -98,18 +127,30 @@ class ARoundViewController: UIViewController, SceneLocationViewDelegate, FilterV
         sceneLocationView.locationDelegate = self
         //sceneLocationView.locationEstimateMethod = .mostRelevantEstimate
         sceneLocationView.locationEstimateMethod = .coreLocationDataOnly
+        
         guard let initialLocation = sceneLocationView.currentLocation() else {
             print("couldn't get current location!")
             return
         }
         currentLocation = initialLocation
-        performFirstSearch()
     }
     
     func performFirstSearch() {
         let categories = [FilterCategory.Food_Beverage, FilterCategory.Fitness_Recreation,
                           FilterCategory.Arts_Entertainment]
-        refreshPins(withCategories: categories)
+
+        guard let coordinates = currentCoordinates else {
+            print("not ready for search - no coordinates!")
+            return
+        }
+        PlaceSearch().fetchPlaces(with: categories, location: coordinates, success: { [weak self] (places: [Place]?) in
+            if let places = places {
+                self?.addPlaces(places: places)
+                self?.mapView.addPlaces(places: places)
+            }
+        }) { (error: Error) in
+            print("Error fetching places with updated filters. Error: \(error)")
+        }
     }
     
     func refreshPins(withCategories categories: [FilterCategory]) {
@@ -163,23 +204,20 @@ class ARoundViewController: UIViewController, SceneLocationViewDelegate, FilterV
         }
     }
     
-    // MARK: - Map setup
-    func initMap()
-    {
-        mapView.alpha = 0.9
-        mapView.delegate = self
-        // Move mapView offscreen (below view)
-        self.view.layoutIfNeeded() // Do this, otherwise frame.height will be incorrect
-        mapTop.constant = mapView.frame.height
-        mapBottom.constant = mapView.frame.height
+    func removeExistingPins() {
+        // Remove existing pins from 3D AR view
+        for (index, currentLocationNode) in locationNodes.enumerated() {
+            sceneLocationView.removeLocationNode(locationNode: currentLocationNode)
+        }
+        locationNodes.removeAll()
+        
+        // Remove pins from 2D map
+        mapView.removeAnnotations()
+        
     }
     
     // MARK: - Button interactions
     @IBAction func onMapButton(_ sender: Any) {
-        
-        // Set up default filter categories for inital launch
-        let categories = [FilterCategory.Food_Beverage, FilterCategory.Fitness_Recreation, FilterCategory.Arts_Entertainment]
-        refreshPins(withCategories: categories)
         
         // Slide map up/down from bottom
         let distance = self.mapBottom?.constant == 0 ? mapView.frame.height : 0
@@ -241,18 +279,6 @@ class ARoundViewController: UIViewController, SceneLocationViewDelegate, FilterV
     func filterViewController(_filterViewController: FilterViewController, didSelectCategories categories: [FilterCategory]) {
 
         refreshPins(withCategories: categories)
-    }
-    
-    func removeExistingPins() {
-        // Remove existing pins from 3D AR view
-        for (index, currentLocationNode) in locationNodes.enumerated() {
-            sceneLocationView.removeLocationNode(locationNode: currentLocationNode)
-        }
-        locationNodes.removeAll()
-        
-        // Remove pins from 2D map
-        mapView.removeAnnotations()
-        
     }
     
     // MARK: - ARMapViewDelegate

--- a/LookARound/Storyboards/Base.lproj/Main.storyboard
+++ b/LookARound/Storyboards/Base.lproj/Main.storyboard
@@ -5,7 +5,6 @@
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
-        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -49,18 +48,10 @@
                                     </button>
                                 </subviews>
                             </stackView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Fu-KV-1Uc" customClass="MapView" customModule="LookARound" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="333.5" width="375" height="333.5"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            </view>
                         </subviews>
                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="3Fu-KV-1Uc" firstAttribute="leading" secondItem="P3l-nB-hn5" secondAttribute="leading" id="G9e-tB-WpR"/>
                             <constraint firstItem="fgH-8Y-Shs" firstAttribute="top" secondItem="P3l-nB-hn5" secondAttribute="top" constant="5" id="TvR-ft-Ckz"/>
-                            <constraint firstItem="3Fu-KV-1Uc" firstAttribute="top" secondItem="mb1-1B-bIi" secondAttribute="centerY" id="Wpq-xQ-4UD"/>
-                            <constraint firstItem="3Fu-KV-1Uc" firstAttribute="trailing" secondItem="P3l-nB-hn5" secondAttribute="trailing" id="ZC5-lL-FbE"/>
-                            <constraint firstItem="3Fu-KV-1Uc" firstAttribute="bottom" secondItem="mb1-1B-bIi" secondAttribute="bottom" id="gc3-s2-Rxn"/>
                             <constraint firstItem="fgH-8Y-Shs" firstAttribute="centerX" secondItem="mb1-1B-bIi" secondAttribute="centerX" id="hbx-yI-uL1"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="P3l-nB-hn5"/>
@@ -69,10 +60,7 @@
                     <connections>
                         <outlet property="contentView" destination="mb1-1B-bIi" id="rKu-IN-KH1"/>
                         <outlet property="filterButton" destination="qwL-JG-K2x" id="bw3-NA-eDc"/>
-                        <outlet property="mapBottom" destination="gc3-s2-Rxn" id="2pf-a8-cJf"/>
                         <outlet property="mapButton" destination="HCu-Wa-LhW" id="GtI-GT-DR4"/>
-                        <outlet property="mapTop" destination="Wpq-xQ-4UD" id="S2r-Bm-9eV"/>
-                        <outlet property="mapView" destination="3Fu-KV-1Uc" id="f9A-D1-TGa"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="SZV-WD-TEh" sceneMemberID="firstResponder"/>

--- a/LookARound/Views/MapView.swift
+++ b/LookARound/Views/MapView.swift
@@ -13,12 +13,13 @@ protocol ARMapViewDelegate : NSObjectProtocol {
     func mapView(mapView : MapView, didSelectPlace place: Place)
 }
 
-class MapView: UIView, CLLocationManagerDelegate, MKMapViewDelegate {
+class MapView: UIView, MKMapViewDelegate {
 
     @IBOutlet var contentView: UIView!
     @IBOutlet weak var mapView: MKMapView!
-    var locValue: CLLocationCoordinate2D!
-    var locationManager : CLLocationManager!
+    var locValue: CLLocationCoordinate2D?
+    var regionRadius: CLLocationDistance = 1000 // default; allow this to get set in the future
+   // var locationManager : CLLocationManager!
 
     var nameToPlaceMapping = [String : Place]()
     weak var delegate : ARMapViewDelegate?
@@ -40,6 +41,12 @@ class MapView: UIView, CLLocationManagerDelegate, MKMapViewDelegate {
         initSubviews()
     }
     
+    init(at center: CLLocationCoordinate2D) {
+        self.init()
+        self.locValue = center
+        initSubviews()
+    }
+    
     func initSubviews() {
         // standard initialization logic
         let nib = UINib(nibName: "MapView", bundle: nil)
@@ -49,13 +56,25 @@ class MapView: UIView, CLLocationManagerDelegate, MKMapViewDelegate {
         
         // set mapview's delegate
         mapView.delegate = self
-        
-        // custom initialization logic
-        locationManager = CLLocationManager()
-        locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
-        locationManager.distanceFilter = 200
-        locationManager.requestWhenInUseAuthorization()
+        guard let currentCoordinates = locValue else {
+            print("no coordinates yet!")
+            return
+        }
+        centerMapOnLocation(coordinates: currentCoordinates)
+
+        // custom initialization logic -- COMMENT OUT TO TEST NEW UNIFIED LM
+//        locationManager = CLLocationManager() // can we access sceneLocationView's location manager instead?
+//        locationManager.delegate = self
+//        locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+//        locationManager.distanceFilter = 200
+//        locationManager.requestWhenInUseAuthorization()
+    }
+
+    func centerMapOnLocation(coordinates: CLLocationCoordinate2D) {
+        let coordinateRegion = MKCoordinateRegionMakeWithDistance(coordinates,
+                                                                  regionRadius * 2.0, regionRadius * 2.0)
+        print("centering")
+        mapView.setRegion(coordinateRegion, animated: true)
     }
     
     func addPlaces( places: [Place] ) {
@@ -71,11 +90,11 @@ class MapView: UIView, CLLocationManagerDelegate, MKMapViewDelegate {
     }
     
     // TODO: John what is this method used for? No one's calling it currently.
-    func goToLocation(location: CLLocation) {
-        let span = MKCoordinateSpanMake(0.1, 0.1)
-        let region = MKCoordinateRegionMake(location.coordinate, span)
-        mapView.setRegion(region, animated: false)
-    }
+//    func goToLocation(location: CLLocation) {
+//        let span = MKCoordinateSpanMake(0.1, 0.1)
+//        let region = MKCoordinateRegionMake(location.coordinate, span)
+//        mapView.setRegion(region, animated: false)
+//    }
     
     // add an Annotation with a coordinate: CLLocationCoordinate2D
     func addAnnotationAtCoordinate(coordinate: CLLocationCoordinate2D, title: String ) {
@@ -91,44 +110,45 @@ class MapView: UIView, CLLocationManagerDelegate, MKMapViewDelegate {
     }
     
     
-    func getCurrentLocation() {
-        let locationManager = CLLocationManager()
-        
-        // Ask for Authorization from the User.
-        self.locationManager.requestAlwaysAuthorization()
-        
-        // For use in foreground
-        self.locationManager.requestWhenInUseAuthorization()
-        
-        if CLLocationManager.locationServicesEnabled() {
-            locationManager.delegate = self
-            locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
-            locationManager.startUpdatingLocation()
-        }
-    }
-    
+    // COMMENT OUT FOR UNIFIED LM
+//    func getCurrentLocation() {
+//        let locationManager = CLLocationManager()
+//
+//        // Ask for Authorization from the User.
+//        self.locationManager.requestAlwaysAuthorization()
+//
+//        // For use in foreground
+//        self.locationManager.requestWhenInUseAuthorization()
+//
+//        if CLLocationManager.locationServicesEnabled() {
+//            locationManager.delegate = self
+//            locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+//            locationManager.startUpdatingLocation()
+//        }
+//    }
+//
 //    func locationManager(manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
 //        var locValue:CLLocationCoordinate2D = manager.location.coordinate
 //        print("locations = \(locValue.latitude) \(locValue.longitude)")
 //    }
     
     // MARK: - CLLocationManagerDelegate
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if status == CLAuthorizationStatus.authorizedWhenInUse {
-            locationManager.startUpdatingLocation()
-        }
-    }
-    
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        if let location = locations.first {
-            let span = MKCoordinateSpanMake(0.1, 0.1)
-            let region = MKCoordinateRegionMake(location.coordinate, span)
-            mapView.setRegion(region, animated: false)
-        }
-        
-        locValue = manager.location!.coordinate
-        print("locations = \(locValue.latitude) \(locValue.longitude)")
-    }
+//    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+//        if status == CLAuthorizationStatus.authorizedWhenInUse {
+//            locationManager.startUpdatingLocation()
+//        }
+//    }
+//
+//    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+//        if let location = locations.first {
+//            let span = MKCoordinateSpanMake(0.1, 0.1)
+//            let region = MKCoordinateRegionMake(location.coordinate, span)
+//            mapView.setRegion(region, animated: false)
+//        }
+//
+//        locValue = manager.location!.coordinate
+//        print("locations = \(locValue.latitude) \(locValue.longitude)")
+//    }
     
     // MARK: - MKMapViewDelegate
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {


### PR DESCRIPTION
This is a big commit. Instantiates MapView programmatically in order to
wait for currentLocation to be determined from sceneLocationView's
locationManager. Also sets mapView region to focus on a distance of
1000 meters.

Adding @hallmont and @alimir1 as reviewers so you are aware of the changes in case any of them affects your Directions work in the 2D map. If it won't affect your Directions work, please comment that it is ok to merge to master.